### PR TITLE
Enable Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     
     - CONDA_PY=27
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "YCno4ZmmpwkDyiaFti4oSA8ibHbrQhZgMKcO4TBx3+xIRoJTmuz8lt+bZsIQQ/8umhHhOpywr1bIIvtZ53xlKeHWrVE1XVaJDW/Iad3p0o239NncaJfjpWoODBWTENpcBE1i/E34ETu26D0G+csE8C7LrDB9O1DAP3dFBkVHAvvLd+vCJUPh8mahcanSGMkzUScD4RmgRrg4wJvBSwgP952MLWiQMv3lTmWnFwDyY0GP4IqNEz/tliK7lZmEBITJEeP73RJpF5u0PdllORNhpESmws88PZxuF0pD2pKdIxw+g8+xA5AM9LFo877qn88tiMxeCBLSgKnPOhRo/VeVTB/QlWNPh0oPVvx2/IwKkqCiAUHqPEpvGnHOORxi1W/gOBY4Ca1Nqq5ykCbL9n1raTuXgnOaiGwgdzvIkp4Omh0zB+DBYeOxqlfDk9+VOM/R1ZWGErK8WSARflnR7X86amRbwouAVaN9H2SEsXJYu/5W3hsflKQO56sz3+2sa9bYEU9VNOrkmsTHVNGGZd7hTdt/IlO6ovPVkBc4IZ9aThzxbCLBZGDkll3a1boqcinQVDM8KgilA4nMcel3ks31bBD9C93BWoZYsLE4907kKmaCzsbO2/Hb5rAqQ0KTQ4ydNq0gaAS4ZuLvUe8Iq80Vy88KZsi9x+/Fx59ZiWo64xs="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,14 @@ environment:
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -57,7 +57,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 2 case(s).
+# Embarking on 3 case(s).
     set -x
     export CONDA_PY=27
     set +x
@@ -66,6 +66,12 @@ source run_conda_forge_build_setup
 
     set -x
     export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ source:
 build:
   number: 0
   script:
-    - export LDFLAGS="-headerpad_max_install_names"  # [osx]
+    - set CL=/FI"%VCINSTALLDIR%\\INCLUDE\\stdint.h" %CL%  # [win and py>=35]
+    - export LDFLAGS="-headerpad_max_install_names"       # [osx]
     - python setup.py install test
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [py>35]
   script:
     - export LDFLAGS="-headerpad_max_install_names"  # [osx]
     - python setup.py install test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - pycrypto_PR_200.diff
 
 build:
-  number: 0
+  number: 1
   script:
     - set CL=/FI"%VCINSTALLDIR%\\INCLUDE\\stdint.h" %CL%  # [win and py>=35]
     - export LDFLAGS="-headerpad_max_install_names"       # [osx]


### PR DESCRIPTION
Fixes https://github.com/conda-forge/pycrypto-feedstock/issues/5
Closes https://github.com/conda-forge/pycrypto-feedstock/pull/3

* Enables Python 3.6 builds of pycrypto.
* Adds a hack to pick up the MSVC provided `stdint.h` if available.

Inspired by this [suggestion]( https://github.com/dlitz/pycrypto/issues/218#issuecomment-304484949 ).